### PR TITLE
Update checkout action so it runs after May 18th

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.2.1'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Checkout v2 runs on Node v12.  This leads to warnings now, but it will stop running after May 18th.