### PR TITLE
Fix input encoding issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2.1'
+          - '3.2.5'
+          - '3.3.6'
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## Fixed
+
+- Fixed reading dump from file (with `--file` option) and from stdin and
+  enforced String binary encoding
+
 ## [0.2.0] - 2023-12-20
 
 ### Added

--- a/lib/marshal-parser/cli/commands.rb
+++ b/lib/marshal-parser/cli/commands.rb
@@ -22,11 +22,11 @@ module MarshalParser
 
           dump = \
             if options[:file]
-              File.read(options[:file])
+              File.read(options[:file]).b
             elsif options[:evaluate]
               Marshal.dump(eval(options[:evaluate]))
             else
-              $stdin.read
+              $stdin.read.b
             end
 
           lexer = MarshalParser::Lexer.new(dump)
@@ -62,11 +62,11 @@ module MarshalParser
 
           dump = \
             if options[:file]
-              File.read(options[:file])
+              File.read(options[:file]).b
             elsif options[:evaluate]
               Marshal.dump(eval(options[:evaluate]))
             else
-              $stdin.read
+              $stdin.read.b
             end
 
           lexer = Lexer.new(dump)

--- a/spec/integration/cli_options_spec.rb
+++ b/spec/integration/cli_options_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe "bin/marshal-cli options" do
       end
     end
 
+    context "--hex option" do
+      it "prints tokens in a hexadecimal encoding" do
+        command = 'ruby -e "puts Marshal.dump(:symbol)" | ruby -Ilib bin/marshal-cli tokens --hex'
+        expect(`#{command}`).to eql(<<~'STR')
+          04 08  3A  0B  73 79 6D 62 6F 6C
+        STR
+      end
+    end
+
     context "--help" do
       it "prints description and options" do
         command = "ruby -Ilib bin/marshal-cli tokens --help"


### PR DESCRIPTION
Input String wasn't encoded into the binary encoding and has UTF-8.

So it led to exceptions `invalid byte sequence in UTF-8 (ArgumentError)` when try to manipulate String characters
and input dump contains binary that are invalid UTF-8 sequences.

The following commands were affected:

- `marshal-cli tokens`
- `marshal-cli ast --only-tokens`

Example of exception:

```
.../lib/marshal-parser/formatters/ast/only_tokens.rb:26:in `block in node_to_entries': invalid byte sequence in UTF-8 (ArgumentError)
	from .../lib/marshal-parser/formatters/ast/only_tokens.rb:22:in `map'
	from .../lib/marshal-parser/formatters/ast/only_tokens.rb:22:in `node_to_entries'
	from .../lib/marshal-parser/formatters/ast/only_tokens.rb:30:in `block in node_to_entries'
```