### PR TITLE
Improve output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Changed output format of the `ast` command and renamed `content` and
   `dump` nodes to `bytes`.
+- Change a symbols table formatting and adjust the indices column width
+  to the maximum index width
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## Changed
+
+- Changed output format of the `ast` command and renamed `content` and
+  `dump` nodes to `bytes`.
+
 ## Fixed
 
 - Fixed reading dump from file (with `--file` option) and from stdin and

--- a/lib/marshal-parser/cli/commands.rb
+++ b/lib/marshal-parser/cli/commands.rb
@@ -97,7 +97,7 @@ module MarshalParser
           if options[:symbols]
             symbols = parser.symbols
             puts ""
-            puts "Symbols table:"
+            puts "Symbols table [#{symbols.size}]:"
             puts MarshalParser::Formatters::Symbols::Table.new(symbols).string
           end
         end

--- a/lib/marshal-parser/formatters/symbols/table.rb
+++ b/lib/marshal-parser/formatters/symbols/table.rb
@@ -9,9 +9,22 @@ module MarshalParser
         end
 
         def string
+          width = digits_in(@symbols.size)
+
           @symbols.map.with_index do |symbol, i|
-            "%-4d - :%s" % [i, symbol]
+            "%-#{width}d - :%s" % [i, symbol]
           end.join("\n")
+        end
+
+        private def digits_in(n)
+          i = 0
+
+          while n > 0
+            i += 1
+            n /= 10
+          end
+
+          i
         end
       end
     end

--- a/lib/marshal-parser/parser.rb
+++ b/lib/marshal-parser/parser.rb
@@ -41,9 +41,9 @@ module MarshalParser
 
       when Lexer::STRING_PREFIX
         length = next_token
-        content = next_token
+        bytes = next_token
 
-        StringNode.new(token, length, content)
+        StringNode.new(token, length, bytes)
 
       when Lexer::OBJECT_WITH_IVARS_PREFIX
         child = build_ast_node
@@ -65,10 +65,10 @@ module MarshalParser
 
       when Lexer::SYMBOL_PREFIX
         length = next_token
-        content = next_token
-        @symbols << @lexer.source_string[content.index, content.length]
+        bytes = next_token
+        @symbols << @lexer.source_string[bytes.index, bytes.length]
 
-        SymbolNode.new(token, length, content, @symbols.size - 1)
+        SymbolNode.new(token, length, bytes, @symbols.size - 1)
 
       when Lexer::TRUE
         TrueNode.new(token)
@@ -207,9 +207,9 @@ module MarshalParser
         assert_node_type class_name_node, SymbolNode, SymbolLinkNode
 
         length = next_token
-        user_dump = next_token
+        bytes = next_token
 
-        ObjectWithDumpMethodNode.new(token, class_name_node, length, user_dump)
+        ObjectWithDumpMethodNode.new(token, class_name_node, length, bytes)
 
       when Lexer::OBJECT_WITH_MARSHAL_DUMP_PREFIX
         class_name_node = build_ast_node
@@ -333,29 +333,29 @@ module MarshalParser
     end
 
     class StringNode < Node
-      def initialize(marker_token, length_token, content_token)
+      def initialize(marker_token, length_token, bytes_token)
         super()
         assert_token_type marker_token, Lexer::STRING_PREFIX
         assert_token_type length_token, Lexer::INTEGER
-        assert_token_type content_token, Lexer::STRING
+        assert_token_type bytes_token, Lexer::STRING
 
         @marker_token = marker_token
         @length_token = length_token
-        @content_token = content_token
+        @bytes_token = bytes_token
       end
 
       def child_entities
-        [@marker_token, @length_token, @content_token]
+        [@marker_token, @length_token, @bytes_token]
       end
 
       def literal_token
-        @content_token
+        @bytes_token
       end
 
       def attributes
         {
           @length_token => { name: :length, value: @length_token.value },
-          @content_token => { name: :content, value: @content_token }
+          @bytes_token => { name: :bytes, value: @bytes_token }
         }
       end
     end
@@ -388,20 +388,20 @@ module MarshalParser
     class SymbolNode < Node
       include Annotatable
 
-      def initialize(marker_token, length_token, content_token, link_to_symbol)
+      def initialize(marker_token, length_token, bytes_token, link_to_symbol)
         super()
         assert_token_type marker_token, Lexer::SYMBOL_PREFIX
         assert_token_type length_token, Lexer::INTEGER
-        assert_token_type content_token, Lexer::SYMBOL
+        assert_token_type bytes_token, Lexer::SYMBOL
 
         @marker_token = marker_token
         @length_token = length_token
-        @content_token = content_token
+        @bytes_token = bytes_token
         @link_to_symbol = link_to_symbol # just Integer, index in the Symbols table
       end
 
       def child_entities
-        [@marker_token, @length_token, @content_token]
+        [@marker_token, @length_token, @bytes_token]
       end
 
       def annotation
@@ -409,13 +409,13 @@ module MarshalParser
       end
 
       def literal_token
-        @content_token
+        @bytes_token
       end
 
       def attributes
         {
           @length_token => { name: :length, value: @length_token.value },
-          @content_token => { name: :content, value: @content_token }
+          @bytes_token => { name: :bytes, value: @bytes_token }
         }
       end
     end
@@ -820,30 +820,30 @@ module MarshalParser
     end
 
     class ObjectWithDumpMethodNode < Node
-      def initialize(token, class_name_node, length, user_dump)
+      def initialize(token, class_name_node, length, bytes)
         super()
         assert_token_type token, Lexer::OBJECT_WITH_DUMP_PREFIX
         assert_token_type length, Lexer::INTEGER
-        assert_token_type user_dump, Lexer::STRING
+        assert_token_type bytes, Lexer::STRING
 
         @prefix = token
         @class_name_node = class_name_node
         @length = length
-        @user_dump = user_dump
+        @bytes = bytes
       end
 
       def child_entities
-        [@prefix, @class_name_node, @length, @user_dump]
+        [@prefix, @class_name_node, @length, @bytes]
       end
 
       def literal_token
-        @user_dump
+        @bytes
       end
 
       def attributes
         {
           @length => { name: :length, value: @length.value },
-          @user_dump => { name: :dump, value: @user_dump }
+          @bytes => { name: :bytes, value: @bytes }
         }
       end
     end

--- a/spec/integration/cli_options_spec.rb
+++ b/spec/integration/cli_options_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "bin/marshal-cli options" do
               (length 6)
               (bytes "symbol")))
 
-          Symbols table:
+          Symbols table [1]:
           0    - :symbol
         STR
       end

--- a/spec/integration/cli_options_spec.rb
+++ b/spec/integration/cli_options_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe "bin/marshal-cli options" do
               (bytes "symbol")))
 
           Symbols table [1]:
-          0    - :symbol
+          0 - :symbol
         STR
       end
     end

--- a/spec/integration/cli_options_spec.rb
+++ b/spec/integration/cli_options_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "bin/marshal-cli options" do
       expect(`#{command}`).to eql(<<~STR)
         (symbol
           (length 6)
-          (content "symbol"))
+          (bytes "symbol"))
       STR
     end
 
@@ -187,7 +187,7 @@ RSpec.describe "bin/marshal-cli options" do
         expect(`#{command}`).to eql(<<~STR)
           (symbol
             (length 6)
-            (content "symbol"))
+            (bytes "symbol"))
         STR
       ensure
         file.unlink
@@ -200,7 +200,7 @@ RSpec.describe "bin/marshal-cli options" do
         expect(`#{command}`).to eql(<<~STR)
           (symbol
             (length 6)
-            (content "symbol"))
+            (bytes "symbol"))
         STR
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe "bin/marshal-cli options" do
           Hello from a.rb
           (symbol
             (length 6)
-            (content "symbol"))
+            (bytes "symbol"))
         EOF
       end
 
@@ -225,7 +225,7 @@ RSpec.describe "bin/marshal-cli options" do
         expect(`#{command}`).to eql(<<~EOF)
           (symbol
             (length 6)
-            (content "symbol"))
+            (bytes "symbol"))
         EOF
       end
     end
@@ -265,7 +265,7 @@ RSpec.describe "bin/marshal-cli options" do
             (true)
             (symbol                                          # symbol #0
               (length 6)
-              (content "symbol")))
+              (bytes "symbol")))
         STR
       end
     end
@@ -281,7 +281,7 @@ RSpec.describe "bin/marshal-cli options" do
             (true)
             (symbol                 # symbol #0
               (length 6)
-              (content "symbol")))
+              (bytes "symbol")))
         STR
       end
     end
@@ -297,7 +297,7 @@ RSpec.describe "bin/marshal-cli options" do
             (true)
             (symbol
               (length 6)
-              (content "symbol")))
+              (bytes "symbol")))
 
           Symbols table:
           0    - :symbol
@@ -369,18 +369,18 @@ RSpec.describe "bin/marshal-cli options" do
             (object-with-dump-method
               (symbol
                 (length 4)
-                (content "Time"))
+                (bytes "Time"))
               (length 8)
-              (dump "5.\x1F\x80\x00\x00\x00\xEC"))
+              (bytes "5.\x1F\x80\x00\x00\x00\xEC"))
             (ivars-count 2)
             (symbol
               (length 6)
-              (content "offset"))
+              (bytes "offset"))
             (integer
               (value 0))
             (symbol
               (length 4)
-              (content "zone"))
+              (bytes "zone"))
             (nil))
         STR
       ensure
@@ -424,18 +424,18 @@ RSpec.describe "bin/marshal-cli options" do
             (object-with-dump-method
               (symbol                                        # symbol #0
                 (length 4)
-                (content "Time"))
+                (bytes "Time"))
               (length 8)
-              (dump "5.\x1F\x80\x00\x00\x00\xEC"))
+              (bytes "5.\x1F\x80\x00\x00\x00\xEC"))
             (ivars-count 2)
             (symbol                                          # symbol #1
               (length 6)
-              (content "offset"))
+              (bytes "offset"))
             (integer
               (value 0))
             (symbol                                          # symbol #2
               (length 4)
-              (content "zone"))
+              (bytes "zone"))
             (nil))
         STR
       end

--- a/spec/marshal-cli/formatters/ast/sexpression_spec.rb
+++ b/spec/marshal-cli/formatters/ast/sexpression_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (object-with-marshal-dump-method
           (symbol
             (length 8)
-            (content "Rational"))
+            (bytes "Rational"))
           (array
             (length 2)
             (integer
@@ -212,7 +212,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (object-with-marshal-dump-method
           (symbol
             (length 7)
-            (content "Complex"))
+            (bytes "Complex"))
           (array
             (length 2)
             (integer
@@ -230,11 +230,11 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (object-with-ivars
           (string
             (length 5)
-            (content "Hello"))
+            (bytes "Hello"))
           (ivars-count 1)
           (symbol
             (length 1)
-            (content "E"))
+            (bytes "E"))
           (true))
       STR
     end
@@ -246,7 +246,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
       expect(formatted_output(dump)).to eq <<~'STR'.b.chomp
         (symbol
           (length 5)
-          (content "Hello"))
+          (bytes "Hello"))
       STR
     end
 
@@ -259,10 +259,10 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (length 3)
           (symbol
             (length 5)
-            (content "Hello"))
+            (bytes "Hello"))
           (symbol
             (length 5)
-            (content "world"))
+            (bytes "world"))
           (symbol-link
             (index 0)))
       STR
@@ -290,7 +290,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (size 1)
             (symbol
               (length 1)
-              (content "a"))
+              (bytes "a"))
             (integer
               (value 0)))
         STR
@@ -321,7 +321,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (size 0)
             (symbol
               (length 6)
-              (content "foobar")))
+              (bytes "foobar")))
         STR
       end
 
@@ -336,7 +336,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (subclass
             (symbol
               (length 4)
-              (content "Hash"))
+              (bytes "Hash"))
             (hash
               (size 0)))
         STR
@@ -351,20 +351,20 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (object
           (symbol
             (length 5)
-            (content "Range"))
+            (bytes "Range"))
           (ivars-count 3)
           (symbol
             (length 4)
-            (content "excl"))
+            (bytes "excl"))
           (false)
           (symbol
             (length 5)
-            (content "begin"))
+            (bytes "begin"))
           (integer
             (value 0))
           (symbol
             (length 3)
-            (content "end"))
+            (bytes "end"))
           (integer
             (value 42)))
       STR
@@ -384,7 +384,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (ivars-count 1)
             (symbol
               (length 1)
-              (content "E"))
+              (bytes "E"))
             (false))
         STR
       end
@@ -402,7 +402,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (ivars-count 1)
             (symbol
               (length 1)
-              (content "E"))
+              (bytes "E"))
             (false))
         STR
       end
@@ -420,18 +420,18 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (object-with-dump-method
               (symbol
                 (length 4)
-                (content "Time"))
+                (bytes "Time"))
               (length 8)
-              (dump "i\xC7\x1E\x80\x00\x00\xE0\xCD"))
+              (bytes "i\xC7\x1E\x80\x00\x00\xE0\xCD"))
             (ivars-count 2)
             (symbol
               (length 6)
-              (content "offset"))
+              (bytes "offset"))
             (integer
               (value 10800))
             (symbol
               (length 4)
-              (content "zone"))
+              (bytes "zone"))
             (nil))
         STR
       end
@@ -447,21 +447,21 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (object-with-dump-method
               (symbol
                 (length 4)
-                (content "Time"))
+                (bytes "Time"))
               (length 8)
-              (dump "l\xC7\x1E\xC0,\x01\xE0\xCD"))
+              (bytes "l\xC7\x1E\xC0,\x01\xE0\xCD"))
             (ivars-count 1)
             (symbol
               (length 4)
-              (content "zone"))
+              (bytes "zone"))
             (object-with-ivars
               (string
                 (length 3)
-                (content "UTC"))
+                (bytes "UTC"))
               (ivars-count 1)
               (symbol
                 (length 1)
-                (content "E"))
+                (bytes "E"))
               (false)))
         STR
       end
@@ -497,11 +497,11 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (struct
           (symbol
             (length 7)
-            (content "StructA"))
+            (bytes "StructA"))
           (count 1)
           (symbol
             (length 1)
-            (content "a"))
+            (bytes "a"))
           (integer
             (value 1)))
       STR
@@ -516,13 +516,13 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (object-with-dump-method
             (symbol
               (length 8)
-              (content "Encoding"))
+              (bytes "Encoding"))
             (length 5)
-            (dump "UTF-8"))
+            (bytes "UTF-8"))
           (ivars-count 1)
           (symbol
             (length 1)
-            (content "E"))
+            (bytes "E"))
           (false))
       STR
     end
@@ -535,9 +535,9 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
         (object-with-dump-method
           (symbol
             (length 10)
-            (content "BigDecimal"))
+            (bytes "BigDecimal"))
           (length 10)
-          (dump "18:0.314e1"))
+          (bytes "18:0.314e1"))
       STR
     end
 
@@ -550,7 +550,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (subclass
             (symbol
               (length 13)
-              (content "ArraySubclass"))
+              (bytes "ArraySubclass"))
             (array
               (length 0)))
         STR
@@ -564,10 +564,10 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (subclass
             (symbol
               (length 14)
-              (content "StringSubclass"))
+              (bytes "StringSubclass"))
             (string
               (length 0)
-              (content "")))
+              (bytes "")))
         STR
       end
 
@@ -579,7 +579,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (subclass
             (symbol
               (length 12)
-              (content "HashSubclass"))
+              (bytes "HashSubclass"))
             (hash
               (size 0)))
         STR
@@ -594,7 +594,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (subclass
               (symbol
                 (length 14)
-                (content "RegexpSubclass"))
+                (bytes "RegexpSubclass"))
               (regexp
                 (length 3)
                 (source-string "abc")
@@ -602,7 +602,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (ivars-count 1)
             (symbol
               (length 1)
-              (content "E"))
+              (bytes "E"))
             (false))
         STR
       end
@@ -617,7 +617,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (object
             (symbol
               (length 6)
-              (content "Object"))
+              (bytes "Object"))
             (ivars-count 0))
         STR
       end
@@ -633,11 +633,11 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (object
             (symbol
               (length 6)
-              (content "Object"))
+              (bytes "Object"))
             (ivars-count 1)
             (symbol
               (length 4)
-              (content "@foo"))
+              (bytes "@foo"))
             (integer
               (value 0)))
         STR
@@ -654,7 +654,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (object
               (symbol
                 (length 6)
-                (content "Object"))
+                (bytes "Object"))
               (ivars-count 0))
             (true)
             (object-link
@@ -671,13 +671,13 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
             (object-with-dump-method
               (symbol
                 (length 11)
-                (content "UserDefined"))
+                (bytes "UserDefined"))
               (length 3)
-              (dump "1:2"))
+              (bytes "1:2"))
             (ivars-count 1)
             (symbol
               (length 1)
-              (content "E"))
+              (bytes "E"))
             (true))
         STR
       end
@@ -690,7 +690,7 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (object-with-marshal-dump-method
             (symbol
               (length 11)
-              (content "UserMarshal"))
+              (bytes "UserMarshal"))
             (array
               (length 2)
               (integer
@@ -711,11 +711,11 @@ RSpec.describe MarshalParser::Formatters::AST::SExpression do
           (object-extended
             (symbol
               (length 10)
-              (content "Comparable"))
+              (bytes "Comparable"))
             (object
               (symbol
                 (length 6)
-                (content "Object"))
+                (bytes "Object"))
               (ivars-count 0)))
         STR
       end

--- a/spec/marshal-cli/formatters/symbols/table_spec.rb
+++ b/spec/marshal-cli/formatters/symbols/table_spec.rb
@@ -7,9 +7,28 @@ RSpec.describe MarshalParser::Formatters::Symbols::Table do
       formatter = described_class.new(symbols)
 
       expect(formatter.string).to eq <<~'STR'.b.chomp
-        0    - :a
-        1    - :b
-        2    - :c
+        0 - :a
+        1 - :b
+        2 - :c
+      STR
+    end
+
+    it "adjust an indices column width to the largest index length" do
+      symbols = (1..11).map(&:to_s)
+      formatter = described_class.new(symbols)
+
+      expect(formatter.string).to eq <<~'STR'.chomp
+        0  - :1
+        1  - :2
+        2  - :3
+        3  - :4
+        4  - :5
+        5  - :6
+        6  - :7
+        7  - :8
+        8  - :9
+        9  - :10
+        10 - :11
       STR
     end
   end


### PR DESCRIPTION
Changes:
- renamed nodes `content` and `dump` to `bytes` in the `ast` command's default output formatter
- updated symbols table and emit number of symbols in the header
- improved symbols table formatting and adjust the indices column width